### PR TITLE
Use BYTEA for xml columns in mindmap models

### DIFF
--- a/wise-api/src/main/java/com/wisemapping/model/InactiveMindmap.java
+++ b/wise-api/src/main/java/com/wisemapping/model/InactiveMindmap.java
@@ -66,8 +66,7 @@ public class InactiveMindmap implements Serializable {
 
     private String title;
 
-    @Column(name = "xml")
-    @Lob
+    @Column(name = "xml", columnDefinition = "BYTEA")
     @Basic(fetch = FetchType.LAZY)
     @LazyGroup("xmlContent")
     @JsonIgnore

--- a/wise-api/src/main/java/com/wisemapping/model/MindMapHistory.java
+++ b/wise-api/src/main/java/com/wisemapping/model/MindMapHistory.java
@@ -41,8 +41,7 @@ public class MindMapHistory {
     @JoinColumn(name = "editor_id", nullable = true,unique = false)
     private Account editor;
 
-    @Column(name = "xml")
-    @Lob
+    @Column(name = "xml", columnDefinition = "BYTEA")
     @Basic(fetch = FetchType.LAZY)
     @LazyGroup("xmlContent")
     private byte[] zippedXml;

--- a/wise-api/src/main/java/com/wisemapping/model/MindmapXml.java
+++ b/wise-api/src/main/java/com/wisemapping/model/MindmapXml.java
@@ -25,7 +25,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
@@ -46,9 +45,8 @@ public class MindmapXml implements Serializable {
     @JsonIgnore
     private Mindmap mindmap;
 
-    @Lob
     @Basic(fetch = FetchType.LAZY)
-    @Column(name = "xml", nullable = false)
+    @Column(name = "xml", nullable = false, columnDefinition = "BYTEA")
     private byte[] zippedXml = new byte[]{};
 
     public MindmapXml() {


### PR DESCRIPTION
Updated the xml column definitions in InactiveMindmap, MindMapHistory, and MindmapXml to use 'BYTEA' for improved binary storage compatibility. Removed unnecessary @Lob annotations where applicable.